### PR TITLE
specify-huggingface_hub-version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ torchaudio>=2.0.2,<=2.2.2
 mediapipe
 transformers>=4.38.2
 diffusers==0.24.0
+huggingface_hub<0.26.0
 torchmetrics
 torchtyping
 tqdm


### PR DESCRIPTION
specify huggingface_hub version to < 0.26.0 to avoid deprecated `cached_download`. More details at: https://github.com/huggingface/huggingface_hub/releases/tag/v0.26.0